### PR TITLE
feat: open typst document

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6341,6 +6341,8 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
+ "tinymist-project",
+ "tyx-tiptap-typst",
  "url",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,12 +20,14 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
+serde.workspace = true
+serde_json.workspace = true
 tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 tauri-plugin-process = "2"
+tinymist-project = { workspace = true, features = ["lsp"] }
+tyx-tiptap-typst.workspace = true
 url = "2.5.4"
 
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]


### PR DESCRIPTION
Closes #20.

This PR only implements typst to tiptap (prose mirror json) importer but not a patcher (patch tiptap changes to the origin typst document). Blocked by #22.

First, I dumped the currently used tiptap schema as [tyx.schema.json](https://github.com/Myriad-Dreamin/TyX/blob/509df7e0fcdc3d70fc33ebfc24cbd7c0c2f4b3a8/crates/tyx-tiptap-schema/assets/tyx.schema.json), then I generate rust structs using the schema.

Then, I compiles the typst document into tiptap json, the conversion path:

```typ
Typst Source Code
  -- typst compilation (HTML export) --> XML
  -- typlite (tinymist) --> Markdown
  -- tyx-tiptap-typst (this PR) --> tiptap json
```

An importer means we can edit any typst documents in TyX but cannot apply changes back to the origin document.

## Example Conversion

Input:

```typ
= Hello, World!
This is a typst document.
```

Output:

```json
{
 "type": "doc",
 "content": [
  {
   "type": "heading",
   "content": [
    {
     "type": "text",
     "content": [
      {
       "type": "plain",
       "content": "Hello, World!"
      }
     ]
    }
   ],
   "dir": null,
   "level": 2
  },
  {
   "type": "paragraph",
   "content": [
    {
     "type": "text",
     "content": [
      {
       "type": "plain",
       "content": "This is a typst document."
      }
     ]
    }
   ],
   "dir": null
  }
 ]
}
```



