### PR TITLE
feat: convert simple typst document to tiptap format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,4 +36,22 @@ Or run:
 bun run tauri dev
 ```
 
+## Testing
+
+To run rust tests, run:
+
+```bash
+cargo test --workspace
+```
+
+## Developing the typst-tiptap Converter
+
+TyX uses tiptap to build its wysiwyg editor. To convert typst documents into tiptap format, TyX adopts a custom converter. The converter is located in [`crates/tyx-tiptap-typst`](./crates/tyx-tiptap-typst).
+
+To perform snapshot testing about the converter, please run:
+
+```bash
+cargo insta test -p tyx-tiptap-typst --accept
+```
+
 <!-- todo: build locally -->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +128,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "archery"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae2ed21cd55021f05707a807a5fc85695dafb98832921f6cfa06db67ca5b869"
+dependencies = [
+ "triomphe",
 ]
 
 [[package]]
@@ -259,6 +318,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +375,16 @@ checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -529,10 +610,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+ "terminal_size",
+ "unicase",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "cmark-writer"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af6cd7a429a8ab9b066867dcb420f71b4eb36566d05d764ffbfff5aee1a84b05"
+dependencies = [
+ "cmark-writer-macros",
+]
+
+[[package]]
+name = "cmark-writer-macros"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01be201bdfedabd81a11363ab87c1bc92baedf90039437bede5eee0ea9ece8d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width 0.1.14",
+]
 
 [[package]]
 name = "codex"
@@ -545,6 +699,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "combine"
@@ -586,6 +746,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -815,6 +987,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-url"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +1133,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "docx-rs"
+version = "0.4.18-rc19"
+source = "git+https://github.com/Myriad-Dreamin/docx-rs?rev=db49a729f68dbdb9e8e91857fbb1c3d414209871#db49a729f68dbdb9e8e91857fbb1c3d414209871"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "xml-rs",
+ "zip 0.6.6",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,6 +1233,21 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "ena"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1221,12 +1434,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "fontconfig-parser"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1fcfcd44ca6e90c921fee9fa665d530b21ef1327a4c1a6c5250ea44b776ada7"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
 name = "fontdb"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37be9fc20d966be438cd57a45767f73349477fb0f85ce86e000557f787298afb"
 dependencies = [
+ "fontconfig-parser",
  "log",
+ "memmap2",
  "slotmap",
  "tinyvec",
  "ttf-parser",
@@ -1269,6 +1493,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,6 +1524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1621,6 +1861,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,6 +1951,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2120,6 +2379,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "image-webp"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79afb8cbee2ef20f59ccd477a218c12a93943d075b492015ecb1bb81f8ee904"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
 name = "imagesize"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2157,6 +2426,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "insta"
+version = "1.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
+dependencies = [
+ "console",
+ "globset",
+ "once_cell",
+ "similar",
+ "walkdir",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,6 +2481,21 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2288,6 +2605,26 @@ dependencies = [
  "bitflags 2.9.0",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -2424,6 +2761,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "lsp-types"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158c1911354ef73e8fe42da6b10c0484cb65c7f1007f28022e847706c1ab6984"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2456,6 +2806,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,6 +2830,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minisign-verify"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,6 +2853,18 @@ checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2584,6 +2965,31 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.9.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "num-bigint"
@@ -3024,10 +3430,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "path-clean"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pdf-writer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df03c7d216de06f93f398ef06f1385a60f2c597bb96f8195c8d98e08a26b1d5"
+dependencies = [
+ "bitflags 2.9.0",
+ "itoa 1.0.15",
+ "memchr",
+ "ryu",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3188,6 +3612,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pixglyph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15afa937836bf3d876f5a04ce28810c06045857bf46c3d0d31073b8aada5494"
+dependencies = [
+ "ttf-parser",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3341,6 +3774,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edecfcd5d755a5e5d98e24cf43113e7cdaec5a070edd0f6b250c03a573da30fa"
 
 [[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3427,6 +3866,12 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3621,6 +4066,7 @@ checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -3633,6 +4079,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3656,6 +4103,23 @@ dependencies = [
  "web-sys",
  "webpki-roots 0.26.11",
  "windows-registry",
+]
+
+[[package]]
+name = "resvg"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7314563c59c7ce31c18e23ad3dd092c37b928a0fa4e1c0a1a6504351ab411d1"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -3684,6 +4148,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3702,6 +4175,15 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rpds"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f89f654d51fffdd6026289d07d1fd523244d46ae0a8bc22caa6dd7f9e8cb0b"
+dependencies = [
+ "archery",
+]
 
 [[package]]
 name = "rust_decimal"
@@ -4096,6 +4578,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "simplecss"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4302,10 +4790,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "subsetter"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35539e8de3dcce8dd0c01f3575f85db1e5ac1aea1b996d2d09d89f148bc91497"
+dependencies = [
+ "fxhash",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svg2pdf"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5014c9dadcf318fb7ef8c16438e95abcc9de1ae24d60d5bccc64c55100c50364"
+dependencies = [
+ "fontdb",
+ "image",
+ "log",
+ "miniz_oxide",
+ "once_cell",
+ "pdf-writer",
+ "resvg",
+ "siphasher 1.0.1",
+ "subsetter",
+ "tiny-skia",
+ "ttf-parser",
+ "usvg",
+]
 
 [[package]]
 name = "svgtypes"
@@ -4454,6 +4971,12 @@ dependencies = [
  "quote",
  "syn 2.0.101",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -4704,7 +5227,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.59.0",
- "zip",
+ "zip 2.6.1",
 ]
 
 [[package]]
@@ -4830,6 +5353,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "thin-slice"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4913,6 +5455,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
 name = "tiny-skia-path"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4921,6 +5478,246 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "strict-num",
+]
+
+[[package]]
+name = "tinymist-analysis"
+version = "0.13.12"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=38974a3b5e43837c1982c707465abfb27d233302#38974a3b5e43837c1982c707465abfb27d233302"
+dependencies = [
+ "comemo",
+ "dashmap",
+ "ecow",
+ "ena",
+ "hashbrown 0.14.5",
+ "if_chain",
+ "itertools",
+ "log",
+ "lsp-types",
+ "parking_lot",
+ "regex",
+ "rpds",
+ "rustc-hash",
+ "serde",
+ "serde_yaml",
+ "strum",
+ "tinymist-derive",
+ "tinymist-std",
+ "tinymist-world",
+ "toml",
+ "triomphe",
+ "typst",
+ "typst-macros 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typst-shim",
+ "typst-timing",
+ "unscanny",
+]
+
+[[package]]
+name = "tinymist-derive"
+version = "0.13.12"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=38974a3b5e43837c1982c707465abfb27d233302#38974a3b5e43837c1982c707465abfb27d233302"
+dependencies = [
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "tinymist-l10n"
+version = "0.13.12"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=38974a3b5e43837c1982c707465abfb27d233302#38974a3b5e43837c1982c707465abfb27d233302"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ecow",
+ "rayon",
+ "rustc-hash",
+ "serde_json",
+ "walkdir",
+]
+
+[[package]]
+name = "tinymist-package"
+version = "0.13.12"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=38974a3b5e43837c1982c707465abfb27d233302#38974a3b5e43837c1982c707465abfb27d233302"
+dependencies = [
+ "base64 0.22.1",
+ "comemo",
+ "dirs",
+ "ecow",
+ "flate2",
+ "log",
+ "parking_lot",
+ "rayon",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tar",
+ "tinymist-std",
+ "toml",
+ "typst",
+ "walkdir",
+]
+
+[[package]]
+name = "tinymist-project"
+version = "0.13.12"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=38974a3b5e43837c1982c707465abfb27d233302#38974a3b5e43837c1982c707465abfb27d233302"
+dependencies = [
+ "anyhow",
+ "clap",
+ "comemo",
+ "dirs",
+ "ecow",
+ "log",
+ "notify",
+ "parking_lot",
+ "rayon",
+ "rpds",
+ "semver",
+ "serde",
+ "serde_json",
+ "tinymist-derive",
+ "tinymist-l10n",
+ "tinymist-std",
+ "tinymist-task",
+ "tinymist-world",
+ "tokio",
+ "toml",
+ "typst",
+ "typst-assets",
+]
+
+[[package]]
+name = "tinymist-std"
+version = "0.13.12"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=38974a3b5e43837c1982c707465abfb27d233302#38974a3b5e43837c1982c707465abfb27d233302"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bitvec",
+ "comemo",
+ "core-foundation",
+ "dashmap",
+ "ecow",
+ "fxhash",
+ "libc",
+ "log",
+ "lsp-types",
+ "parking_lot",
+ "path-clean",
+ "pathdiff",
+ "rustc-hash",
+ "same-file",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "siphasher 1.0.1",
+ "tempfile",
+ "time",
+ "typst",
+ "typst-shim",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tinymist-task"
+version = "0.13.12"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=38974a3b5e43837c1982c707465abfb27d233302#38974a3b5e43837c1982c707465abfb27d233302"
+dependencies = [
+ "anyhow",
+ "clap",
+ "comemo",
+ "dirs",
+ "ecow",
+ "log",
+ "notify",
+ "parking_lot",
+ "rayon",
+ "rpds",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tinymist-derive",
+ "tinymist-std",
+ "tinymist-world",
+ "tokio",
+ "toml",
+ "typst",
+ "typst-assets",
+ "typst-eval",
+ "typst-html",
+ "typst-pdf",
+ "typst-render",
+ "typst-shim",
+ "typst-svg",
+]
+
+[[package]]
+name = "tinymist-tests"
+version = "0.13.12"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=38974a3b5e43837c1982c707465abfb27d233302#38974a3b5e43837c1982c707465abfb27d233302"
+dependencies = [
+ "comemo",
+ "insta",
+ "rayon",
+ "tinymist-analysis",
+ "tinymist-project",
+ "tinymist-std",
+ "typst",
+]
+
+[[package]]
+name = "tinymist-vfs"
+version = "0.13.12"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=38974a3b5e43837c1982c707465abfb27d233302#38974a3b5e43837c1982c707465abfb27d233302"
+dependencies = [
+ "comemo",
+ "ecow",
+ "indexmap 2.9.0",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "rpds",
+ "tinymist-std",
+ "typst",
+]
+
+[[package]]
+name = "tinymist-world"
+version = "0.13.12"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=38974a3b5e43837c1982c707465abfb27d233302#38974a3b5e43837c1982c707465abfb27d233302"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "codespan-reporting",
+ "comemo",
+ "dirs",
+ "ecow",
+ "flate2",
+ "fontdb",
+ "hex",
+ "log",
+ "lsp-types",
+ "parking_lot",
+ "rayon",
+ "reqwest",
+ "rpds",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2",
+ "strum",
+ "tar",
+ "tinymist-package",
+ "tinymist-std",
+ "tinymist-vfs",
+ "ttf-parser",
+ "typst",
+ "typst-assets",
 ]
 
 [[package]]
@@ -4968,12 +5765,24 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
+ "mio 1.0.3",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "tracing",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5143,6 +5952,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5187,10 +6002,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "typlite"
+version = "0.13.12"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=38974a3b5e43837c1982c707465abfb27d233302#38974a3b5e43837c1982c707465abfb27d233302"
+dependencies = [
+ "base64 0.22.1",
+ "clap",
+ "cmark-writer",
+ "comemo",
+ "docx-rs",
+ "ecow",
+ "image",
+ "regex",
+ "resvg",
+ "tinymist-analysis",
+ "tinymist-derive",
+ "tinymist-project",
+ "tinymist-std",
+ "typst",
+ "typst-html",
+ "typst-svg",
+ "typst-syntax",
+]
+
+[[package]]
 name = "typst"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "140458bc8c72b014266f8ea5fad57165c8159845105eea8949c8954b2a8f49f4"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10#946ea31fb554bcf62e3215f64ddda87d70b026af"
 dependencies = [
  "comemo",
  "ecow",
@@ -5198,7 +6036,7 @@ dependencies = [
  "typst-html",
  "typst-layout",
  "typst-library",
- "typst-macros",
+ "typst-macros 0.13.1 (git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10)",
  "typst-realize",
  "typst-syntax",
  "typst-timing",
@@ -5214,8 +6052,7 @@ checksum = "b5bf0cc3c2265502b51fcb73147cc7c951ceb694507195b93c2ab0b901abb902"
 [[package]]
 name = "typst-eval"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "850733c95becdb1b0153fd50e979b06d1a3d42f2411f2a0206b3a793501205ac"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10#946ea31fb554bcf62e3215f64ddda87d70b026af"
 dependencies = [
  "comemo",
  "ecow",
@@ -5224,7 +6061,7 @@ dependencies = [
  "stacker",
  "toml",
  "typst-library",
- "typst-macros",
+ "typst-macros 0.13.1 (git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10)",
  "typst-syntax",
  "typst-timing",
  "typst-utils",
@@ -5234,13 +6071,12 @@ dependencies = [
 [[package]]
 name = "typst-html"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654de5a88b9104f9b19723166eb16b8aec6df72a060d91736b81dc72e905e7cc"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10#946ea31fb554bcf62e3215f64ddda87d70b026af"
 dependencies = [
  "comemo",
  "ecow",
  "typst-library",
- "typst-macros",
+ "typst-macros 0.13.1 (git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10)",
  "typst-svg",
  "typst-syntax",
  "typst-timing",
@@ -5250,8 +6086,7 @@ dependencies = [
 [[package]]
 name = "typst-layout"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc7f7129c44423e54e9943c8a87403a82e8a5a1bdfd3ef08c0aae1b66deec696"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10#946ea31fb554bcf62e3215f64ddda87d70b026af"
 dependencies = [
  "az",
  "bumpalo",
@@ -5269,7 +6104,7 @@ dependencies = [
  "ttf-parser",
  "typst-assets",
  "typst-library",
- "typst-macros",
+ "typst-macros 0.13.1 (git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10)",
  "typst-syntax",
  "typst-timing",
  "typst-utils",
@@ -5282,8 +6117,7 @@ dependencies = [
 [[package]]
 name = "typst-library"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722b0d6dfd05aa5bb7da7f282586f624f452e3f285cd3a10ac0d7e99f3bc3048"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10#946ea31fb554bcf62e3215f64ddda87d70b026af"
 dependencies = [
  "az",
  "bitflags 2.9.0",
@@ -5328,7 +6162,7 @@ dependencies = [
  "two-face",
  "typed-arena",
  "typst-assets",
- "typst-macros",
+ "typst-macros 0.13.1 (git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10)",
  "typst-syntax",
  "typst-timing",
  "typst-utils",
@@ -5353,10 +6187,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "typst-macros"
+version = "0.13.1"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10#946ea31fb554bcf62e3215f64ddda87d70b026af"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "typst-pdf"
+version = "0.13.1"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10#946ea31fb554bcf62e3215f64ddda87d70b026af"
+dependencies = [
+ "arrayvec",
+ "base64 0.22.1",
+ "bytemuck",
+ "comemo",
+ "ecow",
+ "image",
+ "indexmap 2.9.0",
+ "miniz_oxide",
+ "pdf-writer",
+ "serde",
+ "subsetter",
+ "svg2pdf",
+ "ttf-parser",
+ "typst-assets",
+ "typst-library",
+ "typst-macros 0.13.1 (git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10)",
+ "typst-syntax",
+ "typst-timing",
+ "typst-utils",
+ "xmp-writer",
+]
+
+[[package]]
 name = "typst-realize"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc724c3303b9864c01f25292d82c3aa8f0492512bd890836f1fb7242fa5b8af"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10#946ea31fb554bcf62e3215f64ddda87d70b026af"
 dependencies = [
  "arrayvec",
  "bumpalo",
@@ -5364,17 +6235,45 @@ dependencies = [
  "ecow",
  "regex",
  "typst-library",
- "typst-macros",
+ "typst-macros 0.13.1 (git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10)",
  "typst-syntax",
  "typst-timing",
  "typst-utils",
 ]
 
 [[package]]
+name = "typst-render"
+version = "0.13.1"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10#946ea31fb554bcf62e3215f64ddda87d70b026af"
+dependencies = [
+ "bytemuck",
+ "comemo",
+ "image",
+ "pixglyph",
+ "resvg",
+ "tiny-skia",
+ "ttf-parser",
+ "typst-library",
+ "typst-macros 0.13.1 (git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10)",
+ "typst-timing",
+]
+
+[[package]]
+name = "typst-shim"
+version = "0.13.12"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=38974a3b5e43837c1982c707465abfb27d233302#38974a3b5e43837c1982c707465abfb27d233302"
+dependencies = [
+ "cfg-if",
+ "comemo",
+ "typst",
+ "typst-eval",
+ "typst-syntax",
+]
+
+[[package]]
 name = "typst-svg"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "674c8e5cb94015c9f870c48bace6b64eb706075766643f3b1f67606c6b03feae"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10#946ea31fb554bcf62e3215f64ddda87d70b026af"
 dependencies = [
  "base64 0.22.1",
  "comemo",
@@ -5383,7 +6282,7 @@ dependencies = [
  "image",
  "ttf-parser",
  "typst-library",
- "typst-macros",
+ "typst-macros 0.13.1 (git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10)",
  "typst-timing",
  "typst-utils",
  "xmlparser",
@@ -5393,8 +6292,7 @@ dependencies = [
 [[package]]
 name = "typst-syntax"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba949ac75a374ea6b2f61d32e6c63acb818e6179d16f78b2cba988fbb5e23a8"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10#946ea31fb554bcf62e3215f64ddda87d70b026af"
 dependencies = [
  "ecow",
  "serde",
@@ -5411,8 +6309,7 @@ dependencies = [
 [[package]]
 name = "typst-timing"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba4541664e98be2023db2267d92af206190eb903063a0229c668e1ab9dca976"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10#946ea31fb554bcf62e3215f64ddda87d70b026af"
 dependencies = [
  "parking_lot",
  "serde",
@@ -5422,8 +6319,7 @@ dependencies = [
 [[package]]
 name = "typst-utils"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb71d59967e0fb32341f8a94f41ced8da520c63705cca2686ae653c9408fd96"
+source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10#946ea31fb554bcf62e3215f64ddda87d70b026af"
 dependencies = [
  "once_cell",
  "portable-atomic",
@@ -5456,6 +6352,22 @@ dependencies = [
  "serde",
  "serde_json",
  "typst",
+]
+
+[[package]]
+name = "tyx-tiptap-typst"
+version = "0.1.0"
+dependencies = [
+ "cmark-writer",
+ "ecow",
+ "insta",
+ "serde",
+ "serde_json",
+ "tinymist-project",
+ "tinymist-tests",
+ "typlite",
+ "typst",
+ "tyx-tiptap-schema",
 ]
 
 [[package]]
@@ -5530,6 +6442,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5591,6 +6509,18 @@ name = "unicode-vo"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -5678,6 +6608,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -6571,6 +7507,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x11"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6602,6 +7547,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xml-rs"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
+
+[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6612,6 +7563,12 @@ name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "xmp-writer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9e2f4a404d9ebffc0a9832cf4f50907220ba3d7fffa9099261a5cab52f2dd7"
 
 [[package]]
 name = "yaml-rust"
@@ -6790,6 +7747,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,25 @@ panic = "abort"   # Abort on panic
 
 [workspace.dependencies]
 
+cmark-writer = { version = "0.6.3", features = ["gfm"] }
 ecow = { version = "0.2", features = ["serde"] }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
-tyx-tiptap-schema = { path = "crates/tyx-tiptap-schema", version = "0.1.0" }
+insta = "1"
 
+tyx-tiptap-schema = { path = "crates/tyx-tiptap-schema", version = "0.1.0" }
+tyx-tiptap-typst = { path = "crates/tyx-tiptap-typst", version = "0.1.0" }
+
+tinymist-project = "0.13.12"
+tinymist-std = "0.13.12"
+tinymist-task = "0.13.12"
+tinymist-tests = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "38974a3b5e43837c1982c707465abfb27d233302" }
+tinymist-vfs = "0.13.12"
+tinymist-world = "0.13.12"
 typst = "0.13.1"
+typlite = "0.13.12"
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "warn"
@@ -58,3 +69,32 @@ withs = "withs"
 [workspace.metadata.typos.files]
 ignore-hidden = false
 extend-exclude = ["/.git", "fixtures"]
+
+[patch.crates-io]
+
+# todo: remove these typst patch?
+# A regular build MUST use `tag` or `rev` to specify the version of the patched crate to ensure stability.
+typst = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.10" }
+typst-library = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.10" }
+typst-html = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.10" }
+typst-timing = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.10" }
+typst-svg = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.10" }
+typst-render = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.10" }
+typst-pdf = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.10" }
+typst-syntax = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.10" }
+typst-eval = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "tinymist/v0.13.10" }
+
+tinymist-project = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "38974a3b5e43837c1982c707465abfb27d233302" }
+tinymist-std = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "38974a3b5e43837c1982c707465abfb27d233302" }
+tinymist-task = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "38974a3b5e43837c1982c707465abfb27d233302" }
+tinymist-vfs = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "38974a3b5e43837c1982c707465abfb27d233302" }
+tinymist-world = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "38974a3b5e43837c1982c707465abfb27d233302" }
+typlite = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "38974a3b5e43837c1982c707465abfb27d233302" }
+
+# tinymist-project = { path = "../tinymist/crates/tinymist-project" }
+# tinymist-std = { path = "../tinymist/crates/tinymist-std" }
+# tinymist-task = { path = "../tinymist/crates/tinymist-task" }
+# tinymist-tests = { path = "../tinymist/crates/tinymist-tests" }
+# tinymist-vfs = { path = "../tinymist/crates/tinymist-vfs" }
+# tinymist-world = { path = "../tinymist/crates/tinymist-world" }
+# typlite = { path = "../tinymist/crates/typlite" }

--- a/crates/tyx-tiptap-schema/src/generate.rs
+++ b/crates/tyx-tiptap-schema/src/generate.rs
@@ -54,8 +54,8 @@ pub fn run() {
         writer.push_str("#[derive(Debug, Clone, Hash, Serialize, Deserialize)]\n");
         writer.push_str("#[serde(tag = \"type\", rename_all = \"camelCase\")]\n");
         writer.push_str("pub enum TyxNode {\n");
-        writer.push_str("    /// A mark.\n");
-        writer.push_str("    Mark(TyxMark),\n");
+        writer.push_str("    /// A marked content.\n");
+        writer.push_str("    Mark(TyxMarked),\n");
         for node in schema.nodes.values() {
             let name = &node.rust_name;
             writer.push_str(&format!("    /// A `{name}` node.\n"));
@@ -224,17 +224,17 @@ fn generate_node(node: &NodeSchema, writer: &mut Writer) {
     let rust_name = &node.rust_name;
     writer.push_str(&format!("\n/// A `{name}` node.\n"));
     writer.push_str("#[derive(Debug, Clone, Hash, Serialize, Deserialize)]\n");
-    writer.push_str(&format!("pub struct {rust_name} {{\n"));
+    writer.push_str(&format!("pub struct {rust_name} {{"));
     let _ = node;
 
     if node.name == "text" {
-        writer.push_str("    /// The text's mark.\n");
+        writer.push_str("\n    /// The text's mark.\n");
         writer.push_str("    #[serde(skip_serializing_if = \"Vec::is_empty\")]\n");
         writer.push_str("    pub marks: Vec<TyxMark>,\n");
         writer.push_str("    /// The text's content.\n");
         writer.push_str("    pub text: EcoString,\n");
     } else {
-        writer.push_str("    /// The node's content.\n");
+        writer.push_str("\n    /// The node's content.\n");
         writer.push_str("    #[serde(skip_serializing_if = \"Option::is_none\")]\n");
         writer.push_str("    pub content: Option<Content>,\n");
     }
@@ -249,10 +249,7 @@ fn generate_mark(mark: &MarkSchema, writer: &mut Writer) {
     let rust_name = &mark.rust_name;
     writer.push_str(&format!("\n/// A `{name}` mark.\n"));
     writer.push_str("#[derive(Debug, Clone, Hash, Serialize, Deserialize)]\n");
-    writer.push_str(&format!("pub struct {rust_name} {{\n"));
-    writer.push_str("    /// The node's content.\n");
-    writer.push_str("    #[serde(skip_serializing_if = \"Option::is_none\")]\n");
-    writer.push_str("    pub content: Option<Content>,\n");
+    writer.push_str(&format!("pub struct {rust_name} {{"));
     generate_attrs(&mark.attrs, writer);
     writer.push_str("}\n");
 }
@@ -264,7 +261,7 @@ fn generate_attrs(attrs: &Option<BTreeMap<String, Attr>>, writer: &mut Writer) {
     };
     for (name, attr) in attrs {
         let rust_name = make_rust_field(name);
-        writer.push_str(&format!("    /// The `{name}` attribute.\n"));
+        writer.push_str(&format!("\n    /// The `{name}` attribute.\n"));
         let rust_type = match attr.default {
             Some(ref default) => match default {
                 serde_json::Value::Bool(_) => "bool",

--- a/crates/tyx-tiptap-schema/src/lib.rs
+++ b/crates/tyx-tiptap-schema/src/lib.rs
@@ -5,6 +5,7 @@ pub use schema::*;
 mod schema;
 
 use ecow::EcoString;
+use serde::{Deserialize, Serialize};
 
 impl TyxNode {
     /// Creates a plain text node.
@@ -14,4 +15,18 @@ impl TyxNode {
             marks: vec![],
         })
     }
+
+    /// Creates a marked content.
+    pub fn marked(content: Vec<TyxNode>, mark: TyxMark) -> Self {
+        TyxNode::Mark(TyxMarked { mark, content })
+    }
+}
+
+/// A `marked` node.
+#[derive(Debug, Clone, Hash, Serialize, Deserialize)]
+pub struct TyxMarked {
+    /// The node's mark.
+    pub mark: TyxMark,
+    /// The node's content.
+    pub content: Vec<TyxNode>,
 }

--- a/crates/tyx-tiptap-schema/src/schema/mark.rs
+++ b/crates/tyx-tiptap-schema/src/schema/mark.rs
@@ -2,49 +2,33 @@ use super::prelude::*;
 
 /// A `bold` mark.
 #[derive(Debug, Clone, Hash, Serialize, Deserialize)]
-pub struct Bold {
-    /// The node's content.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<Content>,
-}
+pub struct Bold {}
 
 /// A `code` mark.
 #[derive(Debug, Clone, Hash, Serialize, Deserialize)]
-pub struct Code {
-    /// The node's content.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<Content>,
-}
+pub struct Code {}
 
 /// A `highlight` mark.
 #[derive(Debug, Clone, Hash, Serialize, Deserialize)]
-pub struct Highlight {
-    /// The node's content.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<Content>,
-}
+pub struct Highlight {}
 
 /// A `italic` mark.
 #[derive(Debug, Clone, Hash, Serialize, Deserialize)]
-pub struct Italic {
-    /// The node's content.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<Content>,
-}
+pub struct Italic {}
 
 /// A `link` mark.
 #[derive(Debug, Clone, Hash, Serialize, Deserialize)]
 pub struct Link {
-    /// The node's content.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<Content>,
     /// The `class` attribute.
     pub class: serde_json::Value,
+
     /// The `href` attribute.
     pub href: serde_json::Value,
+
     /// The `rel` attribute.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rel: Option<String>,
+
     /// The `target` attribute.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<String>,
@@ -52,50 +36,27 @@ pub struct Link {
 
 /// A `strike` mark.
 #[derive(Debug, Clone, Hash, Serialize, Deserialize)]
-pub struct Strike {
-    /// The node's content.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<Content>,
-}
+pub struct Strike {}
 
 /// A `subscript` mark.
 #[derive(Debug, Clone, Hash, Serialize, Deserialize)]
-pub struct Subscript {
-    /// The node's content.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<Content>,
-}
+pub struct Subscript {}
 
 /// A `superscript` mark.
 #[derive(Debug, Clone, Hash, Serialize, Deserialize)]
-pub struct Superscript {
-    /// The node's content.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<Content>,
-}
+pub struct Superscript {}
 
 /// A `textStyle` mark.
 #[derive(Debug, Clone, Hash, Serialize, Deserialize)]
 pub struct TextStyle {
-    /// The node's content.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<Content>,
     /// The `color` attribute.
     pub color: serde_json::Value,
 }
 
 /// A `typstCode` mark.
 #[derive(Debug, Clone, Hash, Serialize, Deserialize)]
-pub struct TypstCode {
-    /// The node's content.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<Content>,
-}
+pub struct TypstCode {}
 
 /// A `underline` mark.
 #[derive(Debug, Clone, Hash, Serialize, Deserialize)]
-pub struct Underline {
-    /// The node's content.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<Content>,
-}
+pub struct Underline {}

--- a/crates/tyx-tiptap-schema/src/schema/mod.rs
+++ b/crates/tyx-tiptap-schema/src/schema/mod.rs
@@ -10,8 +10,8 @@ use prelude::*;
 #[derive(Debug, Clone, Hash, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum TyxNode {
-    /// A mark.
-    Mark(TyxMark),
+    /// A marked content.
+    Mark(TyxMarked),
     /// A `Blockquote` node.
     Blockquote(Blockquote),
     /// A `BulletList` node.

--- a/crates/tyx-tiptap-schema/src/schema/node.rs
+++ b/crates/tyx-tiptap-schema/src/schema/node.rs
@@ -22,6 +22,7 @@ pub struct CodeBlock {
     /// The node's content.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<Content>,
+
     /// The `language` attribute.
     pub language: serde_json::Value,
 }
@@ -48,11 +49,14 @@ pub struct Heading {
     /// The node's content.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<Content>,
+
     /// The `dir` attribute.
     pub dir: serde_json::Value,
+
     /// The `level` attribute.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub level: Option<i32>,
+
     /// The `textAlign` attribute.
     #[serde(rename = "textAlign")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -81,9 +85,11 @@ pub struct MathBlock {
     /// The node's content.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<Content>,
+
     /// The `json` attribute.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub json: Option<serde_json::Value>,
+
     /// The `value` attribute.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
@@ -95,9 +101,11 @@ pub struct MathInline {
     /// The node's content.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<Content>,
+
     /// The `json` attribute.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub json: Option<serde_json::Value>,
+
     /// The `value` attribute.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
@@ -109,9 +117,11 @@ pub struct OrderedList {
     /// The node's content.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<Content>,
+
     /// The `start` attribute.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub start: Option<i32>,
+
     /// The `type` attribute.
     #[serde(rename = "type")]
     pub ty: serde_json::Value,
@@ -123,8 +133,10 @@ pub struct Paragraph {
     /// The node's content.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<Content>,
+
     /// The `dir` attribute.
     pub dir: serde_json::Value,
+
     /// The `textAlign` attribute.
     #[serde(rename = "textAlign")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -145,11 +157,14 @@ pub struct TableCell {
     /// The node's content.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<Content>,
+
     /// The `colspan` attribute.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub colspan: Option<i32>,
+
     /// The `colwidth` attribute.
     pub colwidth: serde_json::Value,
+
     /// The `rowspan` attribute.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rowspan: Option<i32>,
@@ -161,11 +176,14 @@ pub struct TableHeader {
     /// The node's content.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<Content>,
+
     /// The `colspan` attribute.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub colspan: Option<i32>,
+
     /// The `colwidth` attribute.
     pub colwidth: serde_json::Value,
+
     /// The `rowspan` attribute.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rowspan: Option<i32>,

--- a/crates/tyx-tiptap-schema/src/schema/prelude.rs
+++ b/crates/tyx-tiptap-schema/src/schema/prelude.rs
@@ -1,6 +1,7 @@
-pub use super::{TyxMark, TyxNode};
 pub use ecow::EcoString;
-
 pub use serde::{Deserialize, Serialize};
+
+pub use super::{TyxMark, TyxNode};
+pub use crate::TyxMarked;
 
 pub type Content = Vec<TyxNode>;

--- a/crates/tyx-tiptap-typst/Cargo.toml
+++ b/crates/tyx-tiptap-typst/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tyx-tiptap-typst"
+description = "This crates provides a converter from typst to tiptap."
 version.workspace = true
-description.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/tyx-tiptap-typst/Cargo.toml
+++ b/crates/tyx-tiptap-typst/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "tyx-tiptap-typst"
+version.workspace = true
+description.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+ecow.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tinymist-project = { workspace = true, features = ["lsp"] }
+typlite.workspace = true
+typst.workspace = true
+tyx-tiptap-schema.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+tinymist-tests.workspace = true
+
+[build-dependencies]
+serde.workspace = true
+serde_json.workspace = true
+
+
+[lints]
+workspace = true

--- a/crates/tyx-tiptap-typst/Cargo.toml
+++ b/crates/tyx-tiptap-typst/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+cmark-writer.workspace = true
 ecow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/tyx-tiptap-typst/README.md
+++ b/crates/tyx-tiptap-typst/README.md
@@ -1,0 +1,3 @@
+# TyX Tiptap Typst
+
+This crates provides a converter from typst to tiptap.

--- a/crates/tyx-tiptap-typst/src/fixtures/integration/base.typ
+++ b/crates/tyx-tiptap-typst/src/fixtures/integration/base.typ
@@ -1,0 +1,2 @@
+= Hello, World!
+This is a typst document.

--- a/crates/tyx-tiptap-typst/src/fixtures/integration/link.typ
+++ b/crates/tyx-tiptap-typst/src/fixtures/integration/link.typ
@@ -1,0 +1,1 @@
+https://example.com

--- a/crates/tyx-tiptap-typst/src/fixtures/integration/snaps/convert@base.typ.snap
+++ b/crates/tyx-tiptap-typst/src/fixtures/integration/snaps/convert@base.typ.snap
@@ -1,0 +1,41 @@
+---
+source: crates/tyx-tiptap-typst/src/tests.rs
+expression: conv(world)
+input_file: crates/tyx-tiptap-typst/src/fixtures/integration/base.typ
+---
+{
+ "type": "doc",
+ "content": [
+  {
+   "type": "heading",
+   "content": [
+    {
+     "type": "text",
+     "content": [
+      {
+       "type": "plain",
+       "content": "Hello, World!"
+      }
+     ]
+    }
+   ],
+   "dir": null,
+   "level": 2
+  },
+  {
+   "type": "paragraph",
+   "content": [
+    {
+     "type": "text",
+     "content": [
+      {
+       "type": "plain",
+       "content": "This is a typst document."
+      }
+     ]
+    }
+   ],
+   "dir": null
+  }
+ ]
+}

--- a/crates/tyx-tiptap-typst/src/fixtures/integration/snaps/convert@base.typ.snap
+++ b/crates/tyx-tiptap-typst/src/fixtures/integration/snaps/convert@base.typ.snap
@@ -11,12 +11,7 @@ input_file: crates/tyx-tiptap-typst/src/fixtures/integration/base.typ
    "content": [
     {
      "type": "text",
-     "content": [
-      {
-       "type": "plain",
-       "content": "Hello, World!"
-      }
-     ]
+     "text": "Hello, World!"
     }
    ],
    "dir": null,
@@ -27,12 +22,7 @@ input_file: crates/tyx-tiptap-typst/src/fixtures/integration/base.typ
    "content": [
     {
      "type": "text",
-     "content": [
-      {
-       "type": "plain",
-       "content": "This is a typst document."
-      }
-     ]
+     "text": "This is a typst document."
     }
    ],
    "dir": null

--- a/crates/tyx-tiptap-typst/src/fixtures/integration/snaps/convert@link.typ.snap
+++ b/crates/tyx-tiptap-typst/src/fixtures/integration/snaps/convert@link.typ.snap
@@ -1,0 +1,33 @@
+---
+source: crates/tyx-tiptap-typst/src/tests.rs
+expression: conv(world)
+input_file: crates/tyx-tiptap-typst/src/fixtures/integration/link.typ
+---
+{
+ "type": "doc",
+ "content": [
+  {
+   "type": "paragraph",
+   "content": [
+    {
+     "type": "mark",
+     "type": "link",
+     "content": [
+      {
+       "type": "text",
+       "content": [
+        {
+         "type": "plain",
+         "content": "https://example.com"
+        }
+       ]
+      }
+     ],
+     "class": null,
+     "href": "https://example.com"
+    }
+   ],
+   "dir": null
+  }
+ ]
+}

--- a/crates/tyx-tiptap-typst/src/fixtures/integration/snaps/convert@link.typ.snap
+++ b/crates/tyx-tiptap-typst/src/fixtures/integration/snaps/convert@link.typ.snap
@@ -10,21 +10,15 @@ input_file: crates/tyx-tiptap-typst/src/fixtures/integration/link.typ
    "type": "paragraph",
    "content": [
     {
-     "type": "mark",
-     "type": "link",
-     "content": [
+     "type": "text",
+     "marks": [
       {
-       "type": "text",
-       "content": [
-        {
-         "type": "plain",
-         "content": "https://example.com"
-        }
-       ]
+       "type": "link",
+       "class": null,
+       "href": "https://example.com"
       }
      ],
-     "class": null,
-     "href": "https://example.com"
+     "text": "https://example.com"
     }
    ],
    "dir": null

--- a/crates/tyx-tiptap-typst/src/lib.rs
+++ b/crates/tyx-tiptap-typst/src/lib.rs
@@ -21,7 +21,7 @@ pub use tyx_tiptap_schema::TyxNode;
 
 use std::sync::Arc;
 
-use typlite::ast;
+use cmark_writer::ast;
 use tyx_tiptap_schema::{self as s, TyxMark};
 
 /// The settings for the tyx document.

--- a/crates/tyx-tiptap-typst/src/lib.rs
+++ b/crates/tyx-tiptap-typst/src/lib.rs
@@ -1,0 +1,428 @@
+//! Converts typst document to tiptap elements, using `typlite`.
+//!
+//! ## Example
+//!
+//! Building a world, documented [here](https://github.com/Myriad-Dreamin/tinymist/tree/main/crates/tinymist-world#example-resolves-a-system-universe-from-system-arguments):
+//!
+//! ```no-run
+//! let args = CompileOnceArgs::parse();
+//! let verse = args
+//!     .resolve_system()
+//!     .expect("failed to resolve system universe");
+//!
+//! let world = verse.snapshot();
+//! let tyx_document = tyx_tiptap_typst::convert(world);
+//! ```
+
+use ecow::EcoString;
+use serde::{Deserialize, Serialize};
+pub use tinymist_project::LspWorld;
+pub use tyx_tiptap_schema::TyxNode;
+
+use std::sync::Arc;
+
+use typlite::ast;
+use tyx_tiptap_schema::{self as s, TyxMark};
+
+/// The settings for the tyx document.
+#[derive(Debug, Clone, Hash, Serialize, Deserialize)]
+pub struct TyxSettings {
+    /// The title of the document.
+    pub title: Option<EcoString>,
+}
+
+/// A tyx document for wysiwyg editing.
+#[derive(Debug, Clone, Hash, Serialize, Deserialize)]
+pub struct TyxDocument {
+    /// The version of the document.
+    pub version: String,
+    /// The preamble of the document.
+    pub preamble: String,
+    /// The root node of the document.
+    pub content: TyxNode,
+    /// The settings for the document.
+    pub settings: TyxSettings,
+    /// The filename of the document.
+    pub filename: String,
+    /// Whether the document is dirty.
+    pub dirty: bool,
+}
+
+/// Converts the main document in a [`LspWorld`] to a [`TyxNode`]
+pub fn convert(world: Arc<LspWorld>) -> Option<TyxDocument> {
+    // Converts the source code into a markdown document
+    let converter = typlite::Typlite::new(world);
+    let md_doc = converter.convert_doc(typlite::common::Format::Md).ok()?;
+    // Gets the ast representation
+    let node = md_doc.parse().ok()?;
+
+    // todo: more settings using `typst query`
+    let settings = TyxSettings {
+        title: md_doc.base.info.title.clone(),
+    };
+
+    // Generates the tyx output by walking the node
+    let content = TyxConverter { _base: md_doc.base }.work(node)?;
+
+    Some(TyxDocument {
+        version: "0.1.7".into(),
+        preamble: "".into(),
+        content,
+        settings,
+        filename: String::new(),
+        dirty: false,
+    })
+}
+
+/// Converts a typst document to a tiptap node
+struct TyxConverter {
+    /// The base typst document used for introspection.
+    _base: typst::html::HtmlDocument,
+}
+
+impl TyxConverter {
+    /// The main work function.
+    fn work(&self, node: ast::Node) -> Option<TyxNode> {
+        match node {
+            ast::Node::Document(nodes) => self.document(nodes),
+            ast::Node::ThematicBreak => self.thematic_break(),
+            ast::Node::Heading {
+                level,
+                content,
+                heading_type: _,
+            } => self.heading(level, content),
+            ast::Node::CodeBlock {
+                language,
+                content,
+                block_type: _,
+            } => self.code_block(language, content),
+            ast::Node::HtmlBlock(block) => self.html_block(block),
+            ast::Node::LinkReferenceDefinition {
+                label,
+                destination,
+                title,
+            } => self.link_reference_definition(label, destination, title),
+            ast::Node::Paragraph(nodes) => self.paragraph(nodes),
+            ast::Node::BlockQuote(nodes) => self.block_quote(nodes),
+            ast::Node::OrderedList { start, items } => self.ordered_list(start, items),
+            ast::Node::UnorderedList(list_items) => self.unordered_list(list_items),
+            ast::Node::Table {
+                headers,
+                alignments,
+                rows,
+            } => self.table(headers, alignments, rows),
+            ast::Node::InlineCode(code) => self.inline_code(code),
+            ast::Node::Emphasis(nodes) => self.emphasis(nodes),
+            ast::Node::Strong(nodes) => self.strong(nodes),
+            ast::Node::Strikethrough(nodes) => self.strikethrough(nodes),
+            ast::Node::Link {
+                url,
+                title,
+                content,
+            } => self.link(url, title, content),
+            ast::Node::ReferenceLink { label, content } => self.reference_link(label, content),
+            ast::Node::Image { url, title, alt } => self.image(url, title, alt),
+            ast::Node::Autolink { url, is_email } => self.autolink(url, is_email),
+            ast::Node::ExtendedAutolink(link) => self.extended_autolink(link),
+            ast::Node::HtmlElement(html_element) => self.html_element(html_element),
+            ast::Node::HardBreak => self.hard_break(),
+            ast::Node::SoftBreak => self.soft_break(),
+            ast::Node::Text(content) => self.text(content),
+            ast::Node::Custom(..) => Some(TyxNode::plain(Default::default())),
+        }
+    }
+
+    /// Converts a list of markdown nodes.
+    fn children(&self, nodes: Vec<ast::Node>) -> Vec<TyxNode> {
+        let mut children = Vec::new();
+        for node in nodes {
+            if let Some(child) = self.work(node) {
+                children.push(child);
+            }
+        }
+        children
+    }
+
+    /// Converts a markdown document.
+    fn document(&self, nodes: Vec<ast::Node>) -> Option<TyxNode> {
+        Some(TyxNode::Doc(s::Doc {
+            content: Some(self.children(nodes)),
+        }))
+    }
+
+    /// Converts a thematic break.
+    fn thematic_break(&self) -> Option<TyxNode> {
+        Some(TyxNode::HorizontalRule(s::HorizontalRule { content: None }))
+    }
+
+    /// Converts a heading.
+    fn heading(&self, level: u8, nodes: Vec<ast::Node>) -> Option<TyxNode> {
+        Some(TyxNode::Heading(s::Heading {
+            content: Some(self.children(nodes)),
+            level: Some(level as i32),
+            dir: serde_json::Value::Null,
+            text_align: None,
+        }))
+    }
+
+    /// Converts a code block.
+    fn code_block(&self, language: Option<String>, content: String) -> Option<TyxNode> {
+        Some(TyxNode::CodeBlock(s::CodeBlock {
+            content: Some(vec![TyxNode::plain(content.into())]),
+            language: language
+                .map(serde_json::Value::String)
+                .unwrap_or(serde_json::Value::Null),
+        }))
+    }
+
+    /// Converts a html element, e.g. `<div></div>`.
+    fn html_block(&self, block: String) -> Option<TyxNode> {
+        // todo: what's a html block
+        Some(TyxNode::plain(block.into()))
+    }
+
+    /// Converts a link reference definition.
+    fn link_reference_definition(
+        &self,
+        label: String,
+        destination: String,
+        title: Option<String>,
+    ) -> Option<TyxNode> {
+        // todo: what's a link_reference_definition
+        Some(TyxNode::plain(
+            format!(
+                "link_reference_definition: {} {} {}",
+                label,
+                destination,
+                title.unwrap_or_default()
+            )
+            .into(),
+        ))
+    }
+
+    /// Converts a paragraph.
+    fn paragraph(&self, nodes: Vec<ast::Node>) -> Option<TyxNode> {
+        Some(TyxNode::Paragraph(s::Paragraph {
+            content: Some(self.children(nodes)),
+            dir: serde_json::Value::Null,
+            text_align: None,
+        }))
+    }
+
+    /// Converts a block quote.
+    fn block_quote(&self, nodes: Vec<ast::Node>) -> Option<TyxNode> {
+        Some(TyxNode::Blockquote(s::Blockquote {
+            content: Some(self.children(nodes)),
+        }))
+    }
+
+    /// Converts an ordered list.
+    fn ordered_list(&self, start: u32, items: Vec<ast::ListItem>) -> Option<TyxNode> {
+        let mut children = Vec::new();
+        for item in items {
+            if let Some(child) = self.list_item(item) {
+                children.push(child);
+            }
+        }
+        Some(TyxNode::OrderedList(s::OrderedList {
+            content: Some(children),
+            start: Some(start as i32),
+            ty: serde_json::Value::Null,
+        }))
+    }
+
+    /// Converts an unordered list.
+    fn unordered_list(&self, list_items: Vec<ast::ListItem>) -> Option<TyxNode> {
+        // bulletList
+        let mut children = Vec::new();
+        for item in list_items {
+            if let Some(child) = self.list_item(item) {
+                children.push(child);
+            }
+        }
+
+        Some(TyxNode::BulletList(s::BulletList {
+            content: Some(children),
+        }))
+    }
+
+    /// Converts a list item.
+    fn list_item(&self, item: ast::ListItem) -> Option<TyxNode> {
+        // todo: preserve id.
+        let nodes = match item {
+            ast::ListItem::Unordered { content, .. } => content,
+            ast::ListItem::Ordered { content, .. } => content,
+            ast::ListItem::Task { content, .. } => content,
+        };
+
+        Some(TyxNode::ListItem(s::ListItem {
+            content: Some(self.children(nodes)),
+        }))
+    }
+
+    /// Converts a table.
+    fn table(
+        &self,
+        headers: Vec<ast::Node>,
+        alignments: Vec<ast::TableAlignment>,
+        rows: Vec<Vec<ast::Node>>,
+    ) -> Option<TyxNode> {
+        let mut children = Vec::new();
+        {
+            let mut header_children = Vec::new();
+            for header in headers {
+                if let Some(child) = self.work(header) {
+                    header_children.push(TyxNode::TableHeader(s::TableHeader {
+                        content: Some(vec![child]),
+                        colwidth: serde_json::Value::Null,
+                        colspan: None,
+                        rowspan: None,
+                    }));
+                }
+            }
+            children.push(TyxNode::TableRow(s::TableRow {
+                content: Some(header_children),
+            }));
+
+            // todo: alignments
+            let _ = alignments;
+        }
+
+        for row in rows {
+            let mut row_children = Vec::new();
+            for cell in row {
+                if let Some(child) = self.work(cell) {
+                    row_children.push(TyxNode::TableCell(s::TableCell {
+                        content: Some(vec![child]),
+                        colwidth: serde_json::Value::Null,
+                        colspan: None,
+                        rowspan: None,
+                    }));
+                }
+            }
+            children.push(TyxNode::TableRow(s::TableRow {
+                content: Some(row_children),
+            }));
+        }
+
+        // todo:
+        Some(TyxNode::Table(s::Table {
+            content: Some(children),
+        }))
+    }
+
+    /// Converts an inline code.
+    fn inline_code(&self, code: String) -> Option<TyxNode> {
+        Some(TyxNode::Mark(TyxMark::Code(s::Code {
+            content: Some(vec![TyxNode::plain(code.into())]),
+        })))
+    }
+
+    /// Converts a emphasis.
+    fn emphasis(&self, nodes: Vec<ast::Node>) -> Option<TyxNode> {
+        // todo: we loss semantics here, as an `emphasis` can be configured to be `bold`
+        // or `italic`.
+        Some(TyxNode::Mark(TyxMark::Italic(s::Italic {
+            content: Some(self.children(nodes)),
+        })))
+    }
+
+    /// Converts a strong emphasis.
+    fn strong(&self, nodes: Vec<ast::Node>) -> Option<TyxNode> {
+        Some(TyxNode::Mark(TyxMark::Bold(s::Bold {
+            content: Some(self.children(nodes)),
+        })))
+    }
+
+    /// Converts a strikethrough.
+    fn strikethrough(&self, nodes: Vec<ast::Node>) -> Option<TyxNode> {
+        Some(TyxNode::Mark(TyxMark::Strike(s::Strike {
+            content: Some(self.children(nodes)),
+        })))
+    }
+
+    /// Converts a link.
+    fn link(&self, url: String, title: Option<String>, content: Vec<ast::Node>) -> Option<TyxNode> {
+        let _ = title;
+        Some(TyxNode::Mark(TyxMark::Link(s::Link {
+            content: Some(self.children(content)),
+            rel: None,
+            class: serde_json::Value::Null,
+            target: None,
+            href: serde_json::Value::String(url),
+        })))
+    }
+
+    /// Converts a reference link.
+    fn reference_link(&self, label: String, content: Vec<ast::Node>) -> Option<TyxNode> {
+        let _ = label;
+        Some(TyxNode::Mark(TyxMark::Link(s::Link {
+            content: Some(self.children(content)),
+            rel: None,
+            class: serde_json::Value::Null,
+            target: None,
+            href: serde_json::Value::String(format!("#{label}")),
+        })))
+    }
+
+    /// Converts an image.
+    fn image(&self, url: String, title: Option<String>, alt: Vec<ast::Node>) -> Option<TyxNode> {
+        let _ = title;
+        // todo: there is no image support in tyx yet.
+        Some(TyxNode::Mark(TyxMark::Link(s::Link {
+            content: Some(self.children(alt)),
+            rel: None,
+            class: serde_json::Value::Null,
+            target: None,
+            href: serde_json::Value::String(url),
+        })))
+    }
+
+    /// Converts an autolink.
+    fn autolink(&self, url: String, is_email: bool) -> Option<TyxNode> {
+        let _ = is_email;
+        Some(TyxNode::Mark(TyxMark::Link(s::Link {
+            content: Some(vec![TyxNode::plain(url.as_str().into())]),
+            rel: None,
+            class: serde_json::Value::Null,
+            target: None,
+            href: serde_json::Value::String(url),
+        })))
+    }
+
+    /// Converts an extended autolink.
+    fn extended_autolink(&self, link: String) -> Option<TyxNode> {
+        Some(TyxNode::Mark(TyxMark::Link(s::Link {
+            content: Some(vec![TyxNode::plain(link.as_str().into())]),
+            rel: None,
+            class: serde_json::Value::Null,
+            target: None,
+            href: serde_json::Value::String(link),
+        })))
+    }
+
+    /// Converts a typst html element.
+    fn html_element(&self, _html_element: ast::HtmlElement) -> Option<TyxNode> {
+        // todo: what is a html element
+        None
+    }
+
+    /// Converts a hard break.
+    fn hard_break(&self) -> Option<TyxNode> {
+        Some(TyxNode::HardBreak(s::HardBreak { content: None }))
+    }
+
+    /// Converts a soft break.
+    fn soft_break(&self) -> Option<TyxNode> {
+        // todo: soft break
+        Some(TyxNode::HardBreak(s::HardBreak { content: None }))
+    }
+
+    /// Converts a text node.
+    fn text(&self, content: String) -> Option<TyxNode> {
+        Some(TyxNode::plain(content.into()))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tyx-tiptap-typst/src/tests.rs
+++ b/crates/tyx-tiptap-typst/src/tests.rs
@@ -1,0 +1,34 @@
+use std::{path::PathBuf, sync::Arc};
+
+use serde::Serialize;
+use tinymist_project::LspWorld;
+
+/// Makes snapshot tests for the given function.
+/// The fixtures used for snapshot testing are in the `src/fixtures/{name}`
+/// directory.
+fn snapshot_testing(name: &str, f: &impl Fn(LspWorld, PathBuf)) {
+    tinymist_tests::snapshot_testing!(name, |verse, path| {
+        f(verse.snapshot(), path);
+    });
+}
+
+#[test]
+fn convert() {
+    snapshot_testing("integration", &|world, _path| {
+        insta::assert_snapshot!(conv(world));
+    });
+}
+
+/// Converts the given main document in the world to a string.
+fn conv(world: LspWorld) -> String {
+    let doc = crate::convert(Arc::new(world));
+    // to pretty with indent 1
+    let mut w = Vec::new();
+    let mut s = serde_json::Serializer::with_formatter(
+        &mut w,
+        serde_json::ser::PrettyFormatter::with_indent(b" "),
+    );
+    let node = doc.map(|doc| doc.content);
+    node.serialize(&mut s).expect("failed to serialize");
+    String::from_utf8(w).expect("invalid utf8")
+}


### PR DESCRIPTION
It converts typst document using typlite (that converter from tinymist, which was used for converting typst doc comments to lsp markdown markup). Currently, only the documents in the `crates/tyx-tiptap-typst/src/fixtures/integration/` is ensured to be correct, and the conversion may be buggy. 